### PR TITLE
File delete fix on high load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.2 under development
 
-- no changes in this release.
+- Chg #50. Do not throw exception on file delete when file not found (fix for high concurrency load) (@sartor)
 
 ## 2.0.1 September 18, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.2 under development
 
-- Chg #50. Do not throw exception on file delete when file not found (fix for high concurrency load) (@sartor)
+- Chg #50: Do not throw exception on file delete when file not found (fix for high concurrency load) (@sartor)
 
 ## 2.0.1 September 18, 2022
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -169,7 +169,17 @@ final class FileCache implements CacheInterface
             return true;
         }
 
-        return @unlink($file);
+        $result = @unlink($file);
+        // Check if error was because of file was already deleted by another process on high load
+        if ($result === false) {
+            $lastError = error_get_last();
+            if (str_ends_with($lastError['message'] ?? '', 'No such file or directory')) {
+                error_clear_last();
+                return true;
+            }
+        }
+
+        return $result;
     }
 
     public function clear(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

On high load projects sometimes there is an error trying to delete file. This happens because of not atomic check if file exists and actual delete:
```php
if (!is_file($file)) {
    return true;
}

return @unlink($file);
```

In old yii2 file cache result of key delete not throw any error.
This PR tries to return false only if `unlink` call error caused by any reason except file already deleted
I can't do simple test to prove fix, but I've checked it by calling first `unlink` just after `is_file()` check