### PR TITLE
Apply dirmode to top-level cache directory, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 3.0.1 under development
 
-- Chg #69: Set directoryMode via constructor and deprecate `withDirectoryMode()`
+- Chg #69: Add optional parameter `$directoryMode` to `FileCache` constructor and deprecate `withDirectoryMode()`
+  method (@particleflux)
 
 ## 3.0.0 February 15, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0.1 under development
 
-- no changes in this release.
+- Chg #69: Set directoryMode via constructor and deprecate `withDirectoryMode()`
 
 ## 3.0.0 February 15, 2023
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ the path to the base directory in which the cache files will be stored:
 $cache = new \Yiisoft\Cache\File\FileCache('/path/to/directory');
 ```
 
+Change the permission to be set for newly created directories:
+
+```php
+$cache = new \Yiisoft\Cache\File\FileCache('/path/to/directory', 0777); // default is 0775
+```
+
+This value will be used by PHP `chmod()` function. No umask will be applied. Defaults to 0775,
+meaning the directory is read-writable by an owner and group, but read-only for other users.
+
 Change the suffix of the cache files:
 
 ```php
@@ -52,15 +61,6 @@ $cache = $cache->withFileMode(0644); // default is null
 
 This value will be used by PHP `chmod()` function. No umask will be applied.
 If not set, the permission will be determined by the current environment.
-
-Change the permission to be set for newly created directories:
-
-```php
-$cache = $cache->withDirectoryMode(0777); // default is 0775
-```
-
-This value will be used by PHP `chmod()` function. No umask will be applied. Defaults to 0775,
-meaning the directory is read-writable by an owner and group, but read-only for other users.
 
 Change the level of sub-directories to store cache files:
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -260,7 +260,7 @@ final class FileCache implements CacheInterface
      * This value will be used by PHP chmod() function. No umask will be applied.
      * Defaults to 0775, meaning the directory is read-writable by owner and group, but read-only for other users.
      *
-     * @deprecated Use $directoryMode in the constructor instead
+     * @deprecated Use `$directoryMode` in the constructor instead
      */
     public function withDirectoryMode(int $directoryMode): self
     {

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -50,7 +50,7 @@ final class FileCache implements CacheInterface
 {
     private const TTL_INFINITY = 31_536_000; // 1 year
     private const EXPIRATION_EXPIRED = -1;
-    private const DEFAULT_DIRMODE = 0775;
+    private const DEFAULT_DIRECTORY_MODE = 0775;
 
     /**
      * @var string The directory to store cache files.

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -75,7 +75,7 @@ final class FileCache implements CacheInterface
      * Defaults to 0775, meaning the directory is read-writable by owner and group,
      * but read-only for other users.
      */
-    private int $directoryMode = self::DEFAULT_DIRMODE;
+    private int $directoryMode = self::DEFAULT_DIRECTORY_MODE;
 
     /**
      * @var int The level of sub-directories to store cache files. Defaults to 1.

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -102,7 +102,7 @@ final class FileCache implements CacheInterface
      *
      * @throws CacheException If failed to create cache directory.
      */
-    public function __construct(string $cachePath, int $directoryMode = self::DEFAULT_DIRMODE)
+    public function __construct(string $cachePath, int $directoryMode = self::DEFAULT_DIRECTORY_MODE)
     {
         $this->directoryMode = $directoryMode;
 

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -50,6 +50,7 @@ final class FileCache implements CacheInterface
 {
     private const TTL_INFINITY = 31_536_000; // 1 year
     private const EXPIRATION_EXPIRED = -1;
+    private const DEFAULT_DIRMODE = 0775;
 
     /**
      * @var string The directory to store cache files.
@@ -74,7 +75,7 @@ final class FileCache implements CacheInterface
      * Defaults to 0775, meaning the directory is read-writable by owner and group,
      * but read-only for other users.
      */
-    private int $directoryMode = 0775;
+    private int $directoryMode = self::DEFAULT_DIRMODE;
 
     /**
      * @var int The level of sub-directories to store cache files. Defaults to 1.
@@ -93,13 +94,18 @@ final class FileCache implements CacheInterface
 
     /**
      * @param string $cachePath The directory to store cache files.
+     * @param int $directoryMode The permission to be set for newly created directories.
+     *      This value will be used by PHP chmod() function. No umask will be applied.
+     *      Defaults to 0775, meaning the directory is read-writable by owner and group, but read-only for other users.
      *
      * @see FileCache::$cachePath
      *
      * @throws CacheException If failed to create cache directory.
      */
-    public function __construct(string $cachePath)
+    public function __construct(string $cachePath, int $directoryMode = self::DEFAULT_DIRMODE)
     {
+        $this->directoryMode = $directoryMode;
+
         if (!$this->createDirectoryIfNotExists($cachePath)) {
             throw new CacheException("Failed to create cache directory \"{$cachePath}\".");
         }
@@ -253,6 +259,8 @@ final class FileCache implements CacheInterface
      * @param int $directoryMode The permission to be set for newly created directories.
      * This value will be used by PHP chmod() function. No umask will be applied.
      * Defaults to 0775, meaning the directory is read-writable by owner and group, but read-only for other users.
+     *
+     * @deprecated Use $directoryMode in the constructor instead
      */
     public function withDirectoryMode(int $directoryMode): self
     {

--- a/src/FileCache.php
+++ b/src/FileCache.php
@@ -70,14 +70,6 @@ final class FileCache implements CacheInterface
     private ?int $fileMode = null;
 
     /**
-     * @var int The permission to be set for newly created directories.
-     * This value will be used by PHP chmod() function. No umask will be applied.
-     * Defaults to 0775, meaning the directory is read-writable by owner and group,
-     * but read-only for other users.
-     */
-    private int $directoryMode = self::DEFAULT_DIRECTORY_MODE;
-
-    /**
      * @var int The level of sub-directories to store cache files. Defaults to 1.
      * If the system has huge number of cache files (e.g. one million), you may use a bigger value
      * (usually no bigger than 3). Using sub-directories is mainly to ensure the file system
@@ -94,18 +86,18 @@ final class FileCache implements CacheInterface
 
     /**
      * @param string $cachePath The directory to store cache files.
-     * @param int $directoryMode The permission to be set for newly created directories.
-     *      This value will be used by PHP chmod() function. No umask will be applied.
-     *      Defaults to 0775, meaning the directory is read-writable by owner and group, but read-only for other users.
+     * @param int $directoryMode The permission to be set for newly created directories. This value will be used
+     * by PHP `chmod()` function. No umask will be applied. Defaults to 0775, meaning the directory is read-writable
+     * by owner and group, but read-only for other users.
      *
      * @see FileCache::$cachePath
      *
      * @throws CacheException If failed to create cache directory.
      */
-    public function __construct(string $cachePath, int $directoryMode = self::DEFAULT_DIRECTORY_MODE)
-    {
-        $this->directoryMode = $directoryMode;
-
+    public function __construct(
+        string $cachePath,
+        private int $directoryMode = self::DEFAULT_DIRECTORY_MODE,
+    ) {
         if (!$this->createDirectoryIfNotExists($cachePath)) {
             throw new CacheException("Failed to create cache directory \"{$cachePath}\".");
         }

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -443,7 +443,7 @@ final class FileCacheTest extends TestCase
         $this->assertEquals('0777', $permissions);
     }
 
-    public function testDirMode(): void
+    public function testDirectoryMode(): void
     {
         if ($this->isWindows()) {
             $this->markTestSkipped('Can not test permissions on Windows');

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -422,7 +422,7 @@ final class FileCacheTest extends TestCase
         $this->assertEquals('0755', $permissions);
     }
 
-    public function testDirMode(): void
+    public function testDirModeDeprecated(): void
     {
         if ($this->isWindows()) {
             $this->markTestSkipped('Can not test permissions on Windows');
@@ -440,6 +440,29 @@ final class FileCacheTest extends TestCase
         $cacheFile = $this->invokeMethod($newCache, 'getCacheFile', ['a']);
         $permissions = substr(sprintf('%o', fileperms(dirname($cacheFile))), -4);
 
+        $this->assertEquals('0777', $permissions);
+    }
+
+    public function testDirMode(): void
+    {
+        if ($this->isWindows()) {
+            $this->markTestSkipped('Can not test permissions on Windows');
+        }
+
+        $cache = new FileCache($this->tmpDir, 0777);
+
+        $this->assertInstanceOf(FileCache::class, $cache);
+
+        $cache->set('a', 1);
+        $this->assertSameExceptObject(1, $cache->get('a'));
+
+        $cacheFile = $this->invokeMethod($cache, 'getCacheFile', ['a']);
+        $permissions = substr(sprintf('%o', fileperms(dirname($cacheFile))), -4);
+
+        $this->assertEquals('0777', $permissions);
+
+        // also check top level cache dir permissions
+        $permissions = substr(sprintf('%o', fileperms($this->tmpDir)), -4);
         $this->assertEquals('0777', $permissions);
     }
 

--- a/tests/FileCacheTest.php
+++ b/tests/FileCacheTest.php
@@ -422,7 +422,7 @@ final class FileCacheTest extends TestCase
         $this->assertEquals('0755', $permissions);
     }
 
-    public function testDirModeDeprecated(): void
+    public function testDirectoryModeDeprecated(): void
     {
         if ($this->isWindows()) {
             $this->markTestSkipped('Can not test permissions on Windows');


### PR DESCRIPTION
Due to the cache directory already created in the constructor, if it doesn't exist already it will be created with wrong permissions. The fluent setter for dirMode is only applied after the directory was created.

This re-applies the directory permissions once on `withDirectoryMode()` if they don't match the default.

Fixes #46

Also added a specific test case for checking the cacheDir permissions.

It would seem to me that doing this in the `withDirectoryMode()` setter is probably the best solution, since it won't require checking the mode on every set/get/gc, and only sets it once on init.



| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #46 
